### PR TITLE
Fix: lower order minimum's value to -1

### DIFF
--- a/routes.schema.json
+++ b/routes.schema.json
@@ -108,7 +108,7 @@
           "order": {
             "type": "integer",
             "description": "Determines the order in which this component renders in its default extension slot. Note that this can be overridden by configuration.",
-            "minimum": 0
+            "minimum": -1
           },
           "meta": {
             "type": "object",


### PR DESCRIPTION
Some times we need to use `order: -1`  but we get a warning `Value is below the minimum of 0.` which is scaring somewhat
cc @ibacher @denniskigen 