### PR TITLE
(feat) Add `featureFlag` property to routes.schema.json

### DIFF
--- a/routes.schema.json
+++ b/routes.schema.json
@@ -113,6 +113,10 @@
           "meta": {
             "type": "object",
             "description": "Meta describes any properties that are passed down to the extension when it is loaded"
+          },
+          "featureFlag": {
+            "type": "string",
+            "description": "The name of a feature flag that is defined in the system"
           }
         },
         "required": ["component", "name"]


### PR DESCRIPTION
Adds an optional `featureFlag` property to the extension configuration, fixing the error shown in the screenshot below:


<img width="604" alt="Screenshot 2023-07-20 at 12 27 10 AM" src="https://github.com/openmrs/openmrs-contrib-json-schemas/assets/8509731/de8fb8c5-858e-4fb5-b9ec-551301f11e9d">
