### PR TITLE
Add more render types and update the schema

### DIFF
--- a/form.schema.json
+++ b/form.schema.json
@@ -41,7 +41,14 @@
               "type": "object",
               "properties": {
                 "isExpanded": {
-                  "oneOf": [{ "type": "boolean" }, { "type": "string" }],
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
                   "description": "Either a string or a boolean. \nIf a string value, 'true' means this section should always be rendered in an expanded state, whereas 'false' means it should be rendered in a collapsed state. \nIf a boolean value, true means this section should always be rendered in an expanded state, whereas false means it should be rendered in a collapsed state."
                 },
                 "label": {
@@ -51,7 +58,9 @@
                 "questions": {
                   "type": "array",
                   "description": "An array of all the questions in a section. Questions make up the fields of the form",
-                  "items": { "$ref": "#/definitions/formField" }
+                  "items": {
+                    "$ref": "#/definitions/formField"
+                  }
                 },
                 "isHidden": {
                   "type": "boolean",
@@ -63,7 +72,11 @@
                 },
                 "inlineRendering": {
                   "type": "string",
-                  "enum": ["single-line", "multiline", "automatic"],
+                  "enum": [
+                    "single-line",
+                    "multiline",
+                    "automatic"
+                  ],
                   "description": "Inline rendering options"
                 },
                 "readonly": {
@@ -76,20 +89,29 @@
                 "hide": { "$ref": "#/definitions/hideProps" }
               }
             },
-            "required": ["label", "questions"]
+            "required": [
+              "label",
+              "questions"
+            ]
           },
           "isHidden": {
             "type": "boolean",
             "description": "Determines if the page is hidden"
           },
-          "hide": { "$ref": "#/definitions/hideProps" },
+          "hide": {
+            "$ref": "#/definitions/hideProps"
+          },
           "isSubform": {
             "type": "boolean",
             "description": "Determines if the page is a subform"
           },
           "inlineRendering": {
             "type": "string",
-            "enum": ["single-line", "multiline", "automatic"],
+            "enum": [
+              "single-line",
+              "multiline",
+              "automatic"
+            ],
             "description": "Inline rendering options"
           },
           "readonly": {
@@ -119,7 +141,10 @@
           }
         }
       },
-      "required": ["label", "sections"]
+      "required": [
+        "label",
+        "sections"
+      ]
     },
     "processor": {
       "type": "string",
@@ -160,14 +185,21 @@
             "description": "Alias of the referenced form"
           }
         },
-        "required": ["formName", "alias"]
+        "required": [
+          "formName",
+          "alias"
+        ]
       },
       "description": "Array of referenced forms"
     },
     "encounter": {
       "oneOf": [
-        { "type": "string" },
-        { "$ref": "#/definitions/openmrsEncounter" }
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/openmrsEncounter"
+        }
       ],
       "description": "Encounter information"
     },
@@ -191,8 +223,12 @@
       "items": {
         "type": "object",
         "properties": {
-          "actionId": { "type": "string" },
-          "config": { "type": "object" }
+          "actionId": {
+            "type": "string"
+          },
+          "config": {
+            "type": "object"
+          }
         }
       },
       "description": "Post submission actions"
@@ -200,7 +236,9 @@
     "formOptions": {
       "type": "object",
       "properties": {
-        "usePreviousValueDisabled": { "type": "boolean" }
+        "usePreviousValueDisabled": {
+          "type": "boolean"
+        }
       },
       "description": "Form options"
     },
@@ -235,27 +273,48 @@
       }
     }
   },
-  "required": ["name", "pages"],
+  "required": [
+    "name",
+    "pages"
+  ],
   "definitions": {
     "formSchemaWithoutPostSubmissionActions": {
       "type": "object",
       "properties": {
-        "name": { "type": "string" },
-        "pages": { "type": "array", "items": {} },
-        "processor": { "type": "string" },
-        "uuid": { "type": "string" },
+        "name": {
+          "type": "string"
+        },
+        "pages": {
+          "type": "array",
+          "items": {}
+        },
+        "processor": {
+          "type": "string"
+        },
+        "uuid": {
+          "type": "string"
+        },
         "referencedForms": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "formName": { "type": "string" },
-              "alias": { "type": "string" }
+              "formName": {
+                "type": "string"
+              },
+              "alias": {
+                "type": "string"
+              }
             },
-            "required": ["formName", "alias"]
+            "required": [
+              "formName",
+              "alias"
+            ]
           }
         },
-        "encounterType": { "type": "string" },
+        "encounterType": {
+          "type": "string"
+        },
         "encounter": {
           "oneOf": [{ "type": "string" }, { "type": "object" }]
         },
@@ -270,10 +329,14 @@
         "formOptions": {
           "type": "object",
           "properties": {
-            "usePreviousValueDisabled": { "type": "boolean" }
+            "usePreviousValueDisabled": {
+              "type": "boolean"
+            }
           }
         },
-        "version": { "type": "string" }
+        "version": {
+          "type": "string"
+        }
       },
       "required": [
         "name",
@@ -287,12 +350,27 @@
     "formReference": {
       "type": "object",
       "properties": {
-        "form": { "type": "string" },
-        "page": { "type": "string" },
-        "section": { "type": "string" },
-        "excludeQuestions": { "type": "array", "items": { "type": "string" } }
+        "form": {
+          "type": "string"
+        },
+        "page": {
+          "type": "string"
+        },
+        "section": {
+          "type": "string"
+        },
+        "excludeQuestions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       },
-      "required": ["form", "page", "section"]
+      "required": [
+        "form",
+        "page",
+        "section"
+      ]
     },
     "hideProps": {
       "type": "object",
@@ -302,8 +380,7 @@
           "type": "string",
           "description": "JavaScript expression that determines whether a page or section or question should be hidden or not. If the expression evaluates to true, the page or section or question is hidden. If it evaluates to false, the page or section or question is shown."
         }
-      },
-      "required": ["hideWhenExpression"]
+      }
     },
     "formField": {
       "type": "object",
@@ -334,7 +411,9 @@
         },
         "questions": {
           "type": "array",
-          "items": { "$ref": "#/definitions/formField" },
+          "items": {
+            "$ref": "#/definitions/formField"
+          },
           "description": "Array of sub-questions if this question is a group"
         },
         "value": {
@@ -354,17 +433,23 @@
         },
         "fieldDependants": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Identifiers of fields dependent on this field"
         },
         "pageDependants": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Identifiers of pages dependent on this field"
         },
         "sectionDependants": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Identifiers of sections dependent on this field"
         },
         "required": {
@@ -416,24 +501,38 @@
         },
         "readonly": {
           "oneOf": [
-            { "type": "string", "description": "Readonly status as a string" },
-            { "type": "boolean", "description": "Readonly status as a boolean" }
+            {
+              "type": "string",
+              "description": "Readonly status as a string"
+            },
+            {
+              "type": "boolean",
+              "description": "Readonly status as a boolean"
+            }
           ],
           "description": "Determines if the field is readonly"
         },
         "inlineRendering": {
           "type": "string",
-          "enum": ["single-line", "multiline", "automatic"],
+          "enum": [
+            "single-line",
+            "multiline",
+            "automatic"
+          ],
           "description": "Rendering type for inline display"
         },
         "validators": {
           "type": "array",
-          "items": { "type": "object" },
+          "items": {
+            "type": "object"
+          },
           "description": "Array of validators for the field"
         },
         "behaviours": {
           "type": "array",
-          "items": { "type": "object" },
+          "items": {
+            "type": "object"
+          },
           "description": "Array of behaviours for the field"
         },
         "questionInfo": {
@@ -460,7 +559,12 @@
           "description": "JavaScript expression that resolves to a value from a previous encounter, if available. This value can be used to answer the question."
         }
       },
-      "required": ["label", "type", "questionOptions", "id"],
+      "required": [
+        "label",
+        "type",
+        "questionOptions",
+        "id"
+      ],
       "description": "Definition of a form field"
     },
     "renderType": {
@@ -469,8 +573,10 @@
         "select",
         "text",
         "date",
+        "drug",
         "number",
         "checkbox",
+        "multiCheckbox",
         "datetime",
         "radio",
         "ui-select-extended",
@@ -479,83 +585,191 @@
         "content-switcher",
         "encounter-location",
         "encounter-provider",
+        "encounter-role",
         "textarea",
         "toggle",
         "fixed-value",
-        "file"
+        "file",
+        "problem",
+        "workspace-launcher",
+        "select-concept-answers"
       ]
     },
     "formQuestionOptions": {
       "type": "object",
       "properties": {
-        "extensionId": { "type": "string" },
-        "extensionSlotName": { "type": "string" },
-        "rendering": { "$ref": "#/definitions/renderType" },
-        "concept": { "type": "string" },
-        "max": { "type": "string" },
-        "min": { "type": "string" },
-        "isTransient": { "type": "boolean" },
-        "maxLength": { "type": "string" },
-        "minLength": { "type": "string" },
-        "showDate": { "type": "string" },
+        "extensionId": {
+          "type": "string"
+        },
+        "extensionSlotName": {
+          "type": "string"
+        },
+        "rendering": {
+          "$ref": "#/definitions/renderType"
+        },
+        "concept": {
+          "type": "string"
+        },
+        "max": {
+          "type": "string"
+        },
+        "min": {
+          "type": "string"
+        },
+        "isTransient": {
+          "type": "boolean"
+        },
+        "maxLength": {
+          "type": "string"
+        },
+        "minLength": {
+          "type": "string"
+        },
+        "showDate": {
+          "type": "string"
+        },
+        "showDateOptions": {
+          "type": "object",
+          "properties": {
+            "validators": {
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "showCommentOptions": {
+          "type": "object",
+          "properties": {
+            "validators": {
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "showComment": {
+          "type": "string"
+        },
         "answers": {
           "type": "array",
-          "items": { "type": "object" }
+          "items": {
+            "type": "object"
+          }
         },
-        "weeksList": { "type": "string" },
-        "locationTag": { "type": "string" },
-        "rows": { "type": "integer" },
+        "weeksList": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "locationTag": {
+          "type": "string"
+        },
+        "rows": {
+          "type": "integer"
+        },
         "toggleOptions": {
           "type": "object",
           "properties": {
-            "labelTrue": { "type": "string" },
-            "labelFalse": { "type": "string" }
+            "labelTrue": {
+              "type": "string"
+            },
+            "labelFalse": {
+              "type": "string"
+            }
           }
         },
         "repeatOptions": {
           "type": "object",
           "properties": {
-            "addText": { "type": "string" },
-            "limit": { "type": "string" },
-            "limitExpression": { "type": "string" },
-            "isCloned": { "type": "boolean" }
+            "addText": {
+              "type": "string"
+            },
+            "limit": {
+              "type": "string"
+            },
+            "limitExpression": {
+              "type": "string"
+            },
+            "isCloned": {
+              "type": "boolean"
+            }
           }
         },
         "defaultValue": {},
         "calculate": {
           "type": "object",
           "properties": {
-            "calculateExpression": { "type": "string" }
+            "calculateExpression": {
+              "type": "string"
+            }
           }
         },
         "isDateTime": {
           "type": "object",
           "properties": {
-            "labelTrue": { "type": "boolean" },
-            "labelFalse": { "type": "boolean" }
+            "labelTrue": {
+              "type": "boolean"
+            },
+            "labelFalse": {
+              "type": "boolean"
+            }
           }
         },
-        "usePreviousValueDisabled": { "type": "boolean" },
+        "usePreviousValueDisabled": {
+          "type": "boolean"
+        },
         "allowedFileTypes": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
-        "allowMultiple": { "type": "boolean" },
+        "allowMultiple": {
+          "type": "boolean"
+        },
         "datasource": {
           "type": "object",
           "properties": {
-            "name": { "type": "string" },
-            "config": { "type": "object" }
+            "name": {
+              "type": "string"
+            },
+            "config": {
+              "type": "object"
+            }
           }
         },
-        "isSearchable": { "type": "boolean" }
+        "isSearchable": {
+          "type": "boolean"
+        },
+        "workspaceName": { "type": "string" },
+        "buttonLabel": { "type": "string" },
+        "identifierType": { "type": "string" },
+        "orderSettingUuid": { "type": "string" },
+        "orderType": { "type": "string" },
+        "programUuid": { "type": "string" },
+        "workflowUuid": { "type": "string" },
+        "comment": { "type": "string" },
+        "selectableOrders": { "type": "array", "items": { "type": "object" } }
       }
     },
     "openmrsResource": {
       "type": "object",
       "properties": {
-        "uuid": { "type": "string" },
-        "display": { "type": "string" }
+        "uuid": {
+          "type": "string"
+        },
+        "display": {
+          "type": "string"
+        }
       },
       "additionalProperties": true
     },
@@ -586,11 +800,28 @@
         },
         "obs": {
           "type": "array",
-          "items": { "$ref": "#/definitions/openmrsObs" }
+          "items": {
+            "$ref": "#/definitions/openmrsObs"
+          }
         },
         "orders": {
           "type": "array",
-          "items": { "$ref": "#/definitions/openmrsResource" }
+          "items": {
+            "$ref": "#/definitions/openmrsResource"
+          }
+        },
+        "voided": {
+          "type": "boolean"
+        },
+        "visit": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/openmrsResource"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "voided": { "type": "boolean" },
         "visit": {
@@ -601,12 +832,16 @@
         },
         "encounterProviders": {
           "type": "array",
-          "items": { "type": "object" }
+          "items": {
+            "type": "object"
+          }
         },
         "form": {
           "type": "object",
           "properties": {
-            "uuid": { "type": "string" }
+            "uuid": {
+              "type": "string"
+            }
           },
           "additionalProperties": true
         }
@@ -632,10 +867,18 @@
         "encounter": { "$ref": "#/definitions/openmrsResource" },
         "voided": { "type": "boolean" },
         "value": {},
-        "formFieldPath": { "type": "string" },
-        "formFieldNamespace": { "type": "string" },
-        "status": { "type": "string" },
-        "interpretation": { "type": "string" }
+        "formFieldPath": {
+          "type": "string"
+        },
+        "formFieldNamespace": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "interpretation": {
+          "type": "string"
+        }
       },
       "required": [
         "concept",


### PR DESCRIPTION
## Changes
- This PR adds more `render types` basing on the form-engine latest updates and types currently supported by some forms.
- In this PR, I also updated the `questionOptions` with the latest updates.

NB: I tested with these changes and the rendering errors in the form builder that were due to unexpected types or some required fields are now fixed.

## Ticket
- https://openmrs.atlassian.net/browse/O3-3330