### PR TITLE
(fix) Form Builder Validator Incorrectly Flags "multiCheckbox" Control for "Coded" Datatype as an Error

### DIFF
--- a/form.schema.json
+++ b/form.schema.json
@@ -302,8 +302,7 @@
           "type": "string",
           "description": "JavaScript expression that determines whether a page or section or question should be hidden or not. If the expression evaluates to true, the page or section or question is hidden. If it evaluates to false, the page or section or question is shown."
         }
-      },
-      "required": ["hideWhenExpression"]
+      }
     },
     "formField": {
       "type": "object",
@@ -482,7 +481,13 @@
         "textarea",
         "toggle",
         "fixed-value",
-        "file"
+        "file",
+        "drug",
+        "multiCheckbox",
+        "encounter-role",
+        "problem",
+        "workspace-launcher",
+        "select-concept-answers"
       ]
     },
     "formQuestionOptions": {
@@ -498,11 +503,29 @@
         "maxLength": { "type": "string" },
         "minLength": { "type": "string" },
         "showDate": { "type": "string" },
+        "showDateOptions": {
+          "type": "object",
+          "properties": {
+            "validators": {"items": { "type": "object" }}
+          }
+        },
+        "showCommentOptions": {
+          "type": "object",
+          "properties": {
+            "validators": { "items": { "type": "object" } }
+          }
+        },
+        "showComment": { "type": "string" },
         "answers": {
           "type": "array",
           "items": { "type": "object" }
         },
-        "weeksList": { "type": "string" },
+        "weeksList": { 
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "type": "number" }] } }
+          ]
+        },
         "locationTag": { "type": "string" },
         "rows": { "type": "integer" },
         "toggleOptions": {
@@ -548,7 +571,16 @@
             "config": { "type": "object" }
           }
         },
-        "isSearchable": { "type": "boolean" }
+        "isSearchable": { "type": "boolean" },
+        "workspaceName": { "type": "string" },
+        "buttonLabel": { "type": "string" },
+        "identifierType": { "type": "string" },
+        "orderSettingUuid": { "type": "string" },
+        "orderType": { "type": "string" },
+        "programUuid": { "type": "string" },
+        "workflowUuid": { "type": "string" },
+        "comment": { "type": "string" },
+        "selectableOrders": { "type": "array", "items": { "type": "object" } }
       }
     },
     "openmrsResource": {


### PR DESCRIPTION
## Changes
- This PR adds more `render types` based on the form-engine latest updates and types currently supported by some forms.
- In this PR, I also updated the `questionOptions` with the latest updates.

NB: I tested with these changes and the rendering errors in the form builder that were due to unexpected types or some required fields are now fixed.

## Ticket
- https://openmrs.atlassian.net/browse/O3-3330