### PR TITLE
(fix) Improve workspace2 schema configuration

### DIFF
--- a/form.schema.json
+++ b/form.schema.json
@@ -26,7 +26,7 @@
     },
     "pages": {
       "type": "array",
-      "description": "An array of all the pages in this form. Pages are the the basic unit of a form. They are used to group related sections and questions together.",
+      "description": "An array of all the pages in this form. Pages are the basic unit of a form. They are used to group related sections and questions together.",
       "items": {
         "type": "object",
         "properties": {
@@ -603,7 +603,7 @@
       "properties": {
         "uuid": { "type": "string" },
         "encounterDatetime": {
-          "anyOf": [{ "type": "string" }, { "type": "string" }]
+          "type": "string"
         },
         "patient": {
           "anyOf": [
@@ -658,7 +658,7 @@
         "display": { "type": "string" },
         "concept": { "$ref": "#/definitions/openmrsResource" },
         "obsDatetime": {
-          "anyOf": [{ "type": "string" }, { "type": "string" }]
+          "type": "string"
         },
         "obsGroup": { "$ref": "#/definitions/openmrsObs" },
         "groupMembers": {

--- a/routes.schema.json
+++ b/routes.schema.json
@@ -249,7 +249,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of this worspace. This is used to launch the workspace."
+            "description": "The name of this workspace. This is used to launch the workspace."
           },
           "title": {
             "type": "string",
@@ -346,7 +346,7 @@
           },
           "canMaximize": {
             "type": "boolean",
-            "description": "Weather this workspace window can be maximized to take up the main content area"
+            "description": "Whether this workspace window can be maximized to take up the main content area"
           },
           "group": {
             "type": "string",
@@ -382,7 +382,7 @@
           "persistence": {
             "type": "string",
             "enum": ["app-wide", "closable"],
-            "description": "In app-wide mode, a workspacce group renders its action menu without a close button. In closable mode, the action menu has a cloes button. Defaults to app-wide"
+            "description": "In app-wide mode, a workspace group renders its action menu without a close button. In closable mode, the action menu has a close button. Defaults to app-wide"
           }
         },
         "required": ["name"],

--- a/routes.schema.json
+++ b/routes.schema.json
@@ -348,7 +348,6 @@
             "type": "boolean",
             "description": "Weather this workspace window can be maximized to take up the main content area"
           },
-          "overlay": { "type": "boolean" },
           "group": {
             "type": "string",
             "description": "The name of the workspace group that this window belongs to."
@@ -363,7 +362,7 @@
             "description": "Controls the width of the workspace. The default is \"narrow\" and this should only be changed to \"wider\" if the workspace itself has internal navigation, like the form editor."
           }
         },
-        "required": ["name", "canMaximize", "overlay", "group"],
+        "required": ["name", "group"],
         "additionalProperties": false
       }
     },
@@ -379,6 +378,11 @@
           "overlay": {
             "type": "boolean",
             "description": "Whether the group's windows are rendered on top of (overlaying) the main content or takes up horizontal space to the side of the main content."
+          },
+          "persistence": {
+            "type": "string",
+            "enum": ["app-wide", "closable"],
+            "description": "In app-wide mode, a workspacce group renders its action menu without a close button. In closable mode, the action menu has a cloes button. Defaults to app-wide"
           }
         },
         "required": ["name"],


### PR DESCRIPTION
- `workspaceGroup2.persistence` is added. 
  - In patient chart, the persistence mode is `app-wide`, as the side-nav containing the workspace action buttons are always shown.
  - In the ward app, the persistence mode is `closable`, as the side-nav is only opened when you click on a patient card. The side-nav also displays an `X` button to close it, along with the workspace group.
- `workspaceWindow2.canHide` is removed. A window can be hidden if and only if it has an icon.
- `workspaceWindow2.canMaximize` is now optional
- `workspaceWindow2.overlay` is removed. `workspaceGroups2.overlay` should be used instead.

cc @Muppasanipraneeth 